### PR TITLE
Increased dead-sensitivity for right joysticks

### DIFF
--- a/Game Development Project/ProjectSettings/InputManager.asset
+++ b/Game Development Project/ProjectSettings/InputManager.asset
@@ -302,7 +302,7 @@ InputManager:
     altNegativeButton: 
     altPositiveButton: joystick button 1
     gravity: 1
-    dead: 0.19
+    dead: 0.3
     sensitivity: 0.8
     snap: 0
     invert: 0
@@ -318,7 +318,7 @@ InputManager:
     altNegativeButton: 
     altPositiveButton: joystick button 1
     gravity: 0
-    dead: 0.19
+    dead: 0.3
     sensitivity: 0.8
     snap: 0
     invert: 1


### PR DESCRIPTION
The controller I use to debug is an XBox controller so maybe Playstation controllers require a higher dead range to stop it from constantly drifting the camera angle.