### PR TITLE
Ostrich expressions fix in build

### DIFF
--- a/Game Development Project/Assets/Prefabs/ScenePrefabs/Zeynel.prefab
+++ b/Game Development Project/Assets/Prefabs/ScenePrefabs/Zeynel.prefab
@@ -4181,9 +4181,9 @@ MonoBehaviour:
   InteractText: {fileID: 6686271234746882890}
   DialogText:
   - Hello there!
-  - I'm an image of the main character.
-  - Why I'm not in 3D you ask?
-  - I wish I knew that myself...
+  - I'm an image of the Crocodile npc.
+  - This text is an example text.
+  - Now play this minigame!
 --- !u!1 &7996850063883060242
 GameObject:
   m_ObjectHideFlags: 0

--- a/Game Development Project/Assets/Scenes/CakeMinigame.unity
+++ b/Game Development Project/Assets/Scenes/CakeMinigame.unity
@@ -5770,7 +5770,7 @@ GameObject:
   - component: {fileID: 472186558}
   m_Layer: 5
   m_Name: GoedzoImage
-  m_TagString: OstrichExpressions
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Game Development Project/Assets/Scripts/MiniGames/Cake/NpcAnimationController.cs
+++ b/Game Development Project/Assets/Scripts/MiniGames/Cake/NpcAnimationController.cs
@@ -17,7 +17,7 @@ namespace Assets.Scripts.MiniGames.Cake
 
         public bool Initialized { get; set; }
 
-        void Awake()
+        void Start()
         {
             _npcExpressionsImage = GameObject.FindGameObjectWithTag("OstrichExpressions").GetComponent<Image>();
         }


### PR DESCRIPTION
The problem was a wrongfully assigned tag to one of the game objects. 
Removing this tag from the object fixed the expressions bug.